### PR TITLE
chore: update code review workflow to trigger on PR open and allow manual trigger

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -2,7 +2,15 @@ name: Code Review Bot
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number'
+        required: true
+      branch:
+        description: 'Branch to run on'
+        required: true
 
 jobs:
   run_code_review_bot:
@@ -17,12 +25,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch || github.head_ref }}
 
       - name: Run Code Review Bot
         env:
           OPENROUTER_KEY: ${{ secrets.API_KEY_CODE_REVIEW_BOT }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          PULL_REQUEST_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
         run: github_code_review.sh
 
       - name: Upload artifact including hidden files


### PR DESCRIPTION
The code review bot is too noisy (see https://github.com/mrs-electronics-inc/bots/issues/73). Instead of running it on all PRs events, instead run it on PR creation and allow the user to trigger additional manual runs when they need.