### PR TITLE
feat(tools/mrs-sdk-manager): support installing the demo app source code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .aider*
 .vscode/
 
-build*/
+build/
 .moon/cache/
 
 # CMake stuff

--- a/scripts/install_from_source.sh
+++ b/scripts/install_from_source.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # This script performs all the steps required for building and install the SDK from source.
-# Usage: install_from_source.sh [all|tools|libs]
+# Usage: install_from_source.sh [all|tools|libs|demos]
 
 set -euo pipefail
 
@@ -81,10 +81,10 @@ case "$target" in
 		install_demos
 		;;
 	"--help")
-		echo "Usage: $0 [all|tools|libs]"
+		echo "Usage: $0 [all|tools|libs|demos]"
 		;;
 	*)
-		echo "Usage: $0 [all|tools|libs]" >&2
+		echo "Usage: $0 [all|tools|libs|demos]" >&2
 		exit 1
 		;;
 esac

--- a/scripts/install_from_source.sh
+++ b/scripts/install_from_source.sh
@@ -39,7 +39,19 @@ install_libs() {
 		return 1
 	}
 
-	"$mgr" build-local --install
+	"$mgr" build-local libs --install
+}
+
+# Install source code for the demo apps.
+# This is useful for allowing customers to verify kit setups and test out hardware.
+install_demos() {
+	local -r mgr="$MRS_SDK_QT_ROOT/tools/mrs-sdk-manager"
+	command -v "$mgr" >/dev/null || {
+		echo "ERROR: could not find mrs-sdk-manager at $mgr." >&2
+		return 1
+	}
+
+	"$mgr" build-local demos --install
 }
 
 # Parse out the installation target.
@@ -54,17 +66,19 @@ case "$target" in
 		# Install tooling first because it is used for installing libs.
 		install_tooling
 		install_libs
-		echo "INSTALLATION COMPLETE."
+		install_demos
 		;;
 	"tools")
 		check_env
 		install_tooling
-		echo "INSTALLATION COMPLETE."
 		;;
 	"libs")
 		check_env
 		install_libs
-		echo "INSTALLATION COMPLETE."
+		;;
+	"demos")
+		check_env
+		install_demos
 		;;
 	"--help")
 		echo "Usage: $0 [all|tools|libs]"

--- a/tools/mrs-sdk-manager/README.md
+++ b/tools/mrs-sdk-manager/README.md
@@ -8,6 +8,12 @@ The purpose of the tool is to automate, as much as possible, the process of mana
 
 Compiles the SDK libraries from source for all device/OS targets. The built static libraries will be located in `build/<target>/artifacts`.
 
+The command accepts an optional positional target selector:
+
+- `mrs-sdk-manager build-local` or `mrs-sdk-manager build-local all` — build SDK libraries
+- `mrs-sdk-manager build-local libs` — build SDK libraries only
+- `mrs-sdk-manager build-local demos` — does nothing without `--install`
+
 > NOTE: only `Debug` mode builds are created. We do not yet support `Release` builds because the point of building from source should mostly be for debug purposes.
 
 **Prerequisites:**
@@ -17,7 +23,13 @@ Compiles the SDK libraries from source for all device/OS targets. The built stat
 
 #### `--install` flag
 
-Passing the `--install` flag will automatically create an installation tree in `$HOME/mrs-sdk-qt/0.0.0`. This "development" installation can be used in projects by running `mrs-sdk-manager use 0.0.0`.
+Passing the `--install` flag will automatically create an installation tree in `$MRS_SDK_QT_ROOT/<latest-git-tag>`, where `<latest-git-tag>` comes from `git describe --tags --abbrev=0`. If the repository does not have any tags yet, the install falls back to `$MRS_SDK_QT_ROOT/0.0.0`. This installation can be used like any other by running `mrs-sdk-manager use <latest-git-tag>`.
+
+The flag respects the target selector:
+
+- Passing `all` will install libraries and demos
+- Passing `libs` will install only libraries
+- Passing `demos` will install only demos
 
 ### `env` subcommand
 

--- a/tools/mrs-sdk-manager/build_local/build_local.go
+++ b/tools/mrs-sdk-manager/build_local/build_local.go
@@ -21,8 +21,9 @@ type BuildConfig struct {
 	CmakeCmd []string
 }
 
-// Build builds the SDK library from source for all supported configurations
-func Build() error {
+// Run executes the requested local build scope, optionally installing the
+// compiled SDK libraries before demo builds consume them.
+func Run(scope BuildScope, installFlag bool) error {
 	// Get the current working directory (SDK root)
 	sdkRoot, err := os.Getwd()
 	if err != nil {
@@ -34,14 +35,76 @@ func Build() error {
 		return err
 	}
 
+	envConfig, err := readBuildEnvironment(scope)
+	if err != nil {
+		return err
+	}
+
+	if scope.IncludesLibs() {
+		if err := buildLibraries(sdkRoot, envConfig); err != nil {
+			return err
+		}
+
+		if installFlag {
+			if err := InstallBuilds(sdkRoot); err != nil {
+				return err
+			}
+		}
+	}
+
+	if scope.IncludesDemos() {
+		if installFlag {
+			if err := InstallDemoSources(sdkRoot); err != nil {
+				return err
+			}
+		} else {
+			return fmt.Errorf("--install must be passed when TARGET is all or demos")
+		}
+	}
+
+	return nil
+}
+
+// buildLibraries builds the SDK library from source for all supported
+// configurations.
+func buildLibraries(sdkRoot string, envConfig map[string]string) error {
+	utils.PrintTaskStart("Building MRS SDK libraries from source...")
+	configs := getBuildConfigs(sdkRoot, envConfig)
+	if err := runAllBuilds(sdkRoot, configs); err != nil {
+		return err
+	}
+
+	utils.PrintSuccess("All builds completed successfully")
+	return nil
+}
+
+func readBuildEnvironment(scope BuildScope) (map[string]string, error) {
 	// Read environment config
 	envConfig, err := env.ReadAll()
 	if err != nil {
-		return fmt.Errorf("failed to read environment config: %w", err)
+		return nil, fmt.Errorf("failed to read environment config: %w", err)
 	}
 
-	// Validate all required keys are set
-	requiredKeys := []env.EnvVar{
+	requiredKeys := requiredEnvVarsForScope(scope)
+	var missingKeys []string
+	for _, k := range requiredKeys {
+		if envConfig[k.Key] == "" {
+			missingKeys = append(missingKeys, k.Key)
+		}
+	}
+	if len(missingKeys) > 0 {
+		return nil, fmt.Errorf("missing required environment config: %s\nRun 'mrs-sdk-manager env -w KEY=VALUE' to set them", strings.Join(missingKeys, ", "))
+	}
+
+	return envConfig, nil
+}
+
+func requiredEnvVarsForScope(scope BuildScope) []env.EnvVar {
+	if scope == BuildScopeDemos {
+		return nil
+	}
+
+	return []env.EnvVar{
 		env.YOCTO_QT5_SYSROOT,
 		env.YOCTO_QT5_CXX_COMPILER,
 		env.YOCTO_QT5_ENV_SETUP_SCRIPT,
@@ -51,24 +114,6 @@ func Build() error {
 		env.DESKTOP_QT5_PREFIX,
 		env.DESKTOP_QT6_PREFIX,
 	}
-	var missingKeys []string
-	for _, k := range requiredKeys {
-		if envConfig[k.Key] == "" {
-			missingKeys = append(missingKeys, k.Key)
-		}
-	}
-	if len(missingKeys) > 0 {
-		return fmt.Errorf("missing required environment config: %s\nRun 'mrs-sdk-manager env -w KEY=VALUE' to set them", strings.Join(missingKeys, ", "))
-	}
-
-	utils.PrintTaskStart("Building MRS SDK libraries from source...")
-	configs := getBuildConfigs(sdkRoot, envConfig)
-	if err := runAllBuilds(sdkRoot, configs); err != nil {
-		return err
-	}
-
-	utils.PrintSuccess("All builds completed successfully")
-	return nil
 }
 
 // verifyRepoRoot verifies that we're in the mrs-sdk-qt repository root

--- a/tools/mrs-sdk-manager/build_local/build_local_install.go
+++ b/tools/mrs-sdk-manager/build_local/build_local_install.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"mrs-sdk-manager/utils"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -27,8 +28,11 @@ func InstallBuilds(sdkRepoRoot string) error {
 		return fmt.Errorf("failed to create SDK root directory: %w", err)
 	}
 
-	// Default to version 0.0.0 for local/dev builds
-	const sdkVersion = "0.0.0"
+	// Mirror the versioning strategy used by the library CMake build so that a
+	// repo-local `build-local --install` produces an installation tree under the
+	// same version label that the compiled artifacts report internally. The
+	// historical 0.0.0 fallback remains in place for untagged development clones.
+	sdkVersion := utils.ResolveSDKVersion(sdkRepoRoot)
 	sdkDevVersionRoot := filepath.Join(sdkInstallRoot, sdkVersion)
 
 	// Install include files and CMake/QMake files (only once)
@@ -41,6 +45,29 @@ func InstallBuilds(sdkRepoRoot string) error {
 	}
 
 	utils.PrintSuccess("All SDK components installed successfully")
+	return nil
+}
+
+// InstallDemoSources copies the repository demo source tree into the
+// versioned SDK installation so consumers can check out example projects
+// without needing generated wrapper files tracked in Git.
+func InstallDemoSources(sdkRepoRoot string) error {
+	sdkInstallRoot, err := utils.ResolveSDKInstallRoot()
+	if err != nil {
+		return err
+	}
+
+	sdkVersion := utils.ResolveSDKVersion(sdkRepoRoot)
+	demoInstallRoot := filepath.Join(sdkInstallRoot, sdkVersion, "demos")
+	demoSourceRoot := filepath.Join(sdkRepoRoot, "demos")
+
+	utils.PrintTaskStart(fmt.Sprintf("Installing demo sources in %s...", demoInstallRoot))
+
+	if err := copyDirectory(demoSourceRoot, demoInstallRoot); err != nil {
+		return fmt.Errorf("failed to copy demo sources: %w", err)
+	}
+
+	utils.PrintSuccess("All demo sources installed successfully")
 	return nil
 }
 
@@ -158,6 +185,11 @@ func copyFile(src, dst string) error {
 
 // copyDirectory recursively copies a directory from src to dst
 func copyDirectory(src, dst string) error {
+	trackedFiles, trackedDirs, err := trackedPathsForDirectory(src)
+	if err != nil {
+		return err
+	}
+
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -167,6 +199,16 @@ func copyDirectory(src, dst string) error {
 		relPath, err := filepath.Rel(src, path)
 		if err != nil {
 			return err
+		}
+
+		if relPath != "." {
+			if info.IsDir() {
+				if _, ok := trackedDirs[relPath]; !ok {
+					return filepath.SkipDir
+				}
+			} else if _, ok := trackedFiles[relPath]; !ok {
+				return nil
+			}
 		}
 
 		dstPath := filepath.Join(dst, relPath)
@@ -183,4 +225,54 @@ func copyDirectory(src, dst string) error {
 			return os.WriteFile(dstPath, data, info.Mode().Perm())
 		}
 	})
+}
+
+func trackedPathsForDirectory(src string) (map[string]struct{}, map[string]struct{}, error) {
+	gitRootOutput, err := exec.Command("git", "-C", src, "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve git root for %s: %w", src, err)
+	}
+
+	gitRoot := strings.TrimSpace(string(gitRootOutput))
+	srcRelToGitRoot, err := filepath.Rel(gitRoot, src)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve %s relative to git root %s: %w", src, gitRoot, err)
+	}
+
+	lsFilesCmd := exec.Command("git", "-C", src, "ls-files", "--full-name", "--", ".")
+	lsFilesOutput, err := lsFilesCmd.Output()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list tracked files for %s: %w", src, err)
+	}
+
+	trackedFiles := map[string]struct{}{}
+	trackedDirs := map[string]struct{}{
+		".": {},
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(lsFilesOutput)), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		trackedRelPath, err := filepath.Rel(srcRelToGitRoot, filepath.FromSlash(line))
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to resolve tracked path %s relative to %s: %w", line, src, err)
+		}
+
+		if trackedRelPath == "." || strings.HasPrefix(trackedRelPath, "..") {
+			continue
+		}
+
+		trackedRelPath = filepath.Clean(trackedRelPath)
+		trackedFiles[trackedRelPath] = struct{}{}
+
+		parent := filepath.Dir(trackedRelPath)
+		for parent != "." && parent != string(filepath.Separator) {
+			trackedDirs[parent] = struct{}{}
+			parent = filepath.Dir(parent)
+		}
+	}
+
+	return trackedFiles, trackedDirs, nil
 }

--- a/tools/mrs-sdk-manager/build_local/build_local_install_test.go
+++ b/tools/mrs-sdk-manager/build_local/build_local_install_test.go
@@ -2,10 +2,42 @@ package buildlocal
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// TestInstallDemoSourcesUsesTaggedVersion verifies that demo source installs
+// land under the same versioned SDK directory as the rest of the local install
+// tree when the repository has a release tag.
+func TestInstallDemoSourcesUsesTaggedVersion(t *testing.T) {
+	repoRoot := t.TempDir()
+	sdkRoot := filepath.Join(t.TempDir(), "custom-sdk-root")
+
+	t.Setenv("MRS_SDK_QT_ROOT", sdkRoot)
+
+	initTestRepo(t, repoRoot)
+	writeTestFile(t, filepath.Join(repoRoot, "README.md"), "initial")
+	runGit(t, repoRoot, "add", "README.md")
+	runGit(t, repoRoot, "commit", "-m", "initial commit")
+	runGit(t, repoRoot, "tag", "1.2.3")
+
+	createFakeDemoRepo(t, repoRoot)
+
+	if err := InstallDemoSources(repoRoot); err != nil {
+		t.Fatalf("InstallDemoSources returned error: %v", err)
+	}
+
+	demoRoot := filepath.Join(sdkRoot, "1.2.3", "demos")
+	assertFileExists(t, filepath.Join(demoRoot, "README.md"))
+	assertFileExists(t, filepath.Join(demoRoot, "can-simulator", "can-simulator.pro"))
+	assertFileExists(t, filepath.Join(demoRoot, "spoke-zone-demo", "CMakeLists.txt"))
+
+	assertFileMissing(t, filepath.Join(demoRoot, "can-simulator", "mrs-sdk-qt", "version.conf"))
+	assertFileMissing(t, filepath.Join(demoRoot, "spoke-zone-demo", ".qtcreator", "CMakeLists.txt.user"))
+	assertFileMissing(t, filepath.Join(demoRoot, "spoke-zone-demo", "build", "artifact"))
+}
 
 // TestInstallBuildsUsesConfiguredSDKRoot verifies that local installs honor
 // MRS_SDK_QT_ROOT instead of silently writing into the default home-directory
@@ -18,6 +50,7 @@ func TestInstallBuildsUsesConfiguredSDKRoot(t *testing.T) {
 	t.Setenv("HOME", homeDir)
 	t.Setenv("MRS_SDK_QT_ROOT", sdkRoot)
 
+	initTestRepo(t, repoRoot)
 	createFakeSDKRepo(t, repoRoot)
 
 	if err := InstallBuilds(repoRoot); err != nil {
@@ -39,6 +72,17 @@ func TestInstallBuildsUsesConfiguredSDKRoot(t *testing.T) {
 	}
 }
 
+// initTestRepo creates a minimal Git repository fixture with a deterministic
+// identity so tests can exercise Git-aware install logic without depending on
+// any global user configuration.
+func initTestRepo(t *testing.T, repoRoot string) {
+	t.Helper()
+
+	runGit(t, repoRoot, "init")
+	runGit(t, repoRoot, "config", "user.name", "Test User")
+	runGit(t, repoRoot, "config", "user.email", "test@example.com")
+}
+
 // TestInstallBuildsRequiresSDKRoot verifies that install commands fail fast
 // when the configured SDK root is missing instead of guessing a default path.
 func TestInstallBuildsRequiresSDKRoot(t *testing.T) {
@@ -53,6 +97,21 @@ func TestInstallBuildsRequiresSDKRoot(t *testing.T) {
 	}
 }
 
+// runGit executes a Git command in the test repository and fails the test with
+// the full command output if Git refuses the operation. Keeping the helper here
+// avoids repetitive boilerplate in individual version-resolution tests while
+// still surfacing the exact failing subprocess invocation.
+func runGit(t *testing.T, repoRoot string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+}
+
 // createFakeSDKRepo builds the minimal repository layout that InstallBuilds
 // expects so the test can validate copy destinations without running the full
 // native and cross-compilation toolchains.
@@ -62,10 +121,32 @@ func createFakeSDKRepo(t *testing.T, repoRoot string) {
 	writeTestFile(t, filepath.Join(repoRoot, "lib", "include", "mrs-sdk-qt", "sdk.hpp"), "header")
 	writeTestFile(t, filepath.Join(repoRoot, "lib", "cmake", "mrs-sdk-qt", "config.cmake"), "cmake")
 	writeTestFile(t, filepath.Join(repoRoot, "lib", "qmake", "mrs-sdk-qt", "config.pri"), "qmake")
+	runGit(t, repoRoot, "add", "lib")
 
 	for _, target := range AllBuildTargets() {
 		writeTestFile(t, filepath.Join(repoRoot, "build", target.BuildDir(), "artifacts", "libmrs-sdk-qt.a"), target.BuildDir())
 	}
+}
+
+// createFakeDemoRepo builds the minimal demo tree expected by the demo-source
+// installer, including generated and editor-specific directories that must be
+// excluded from the copied SDK installation.
+func createFakeDemoRepo(t *testing.T, repoRoot string) {
+	t.Helper()
+
+	writeTestFile(t, filepath.Join(repoRoot, "demos", "README.md"), "demo docs")
+	writeTestFile(t, filepath.Join(repoRoot, "demos", "can-simulator", "can-simulator.pro"), "TEMPLATE = app")
+	writeTestFile(t, filepath.Join(repoRoot, "demos", "can-simulator", "main.cpp"), "int main() {}")
+	writeTestFile(t, filepath.Join(repoRoot, "demos", "can-simulator", "mrs-sdk-qt", "version.conf"), "MRS_SDK_QT_VERSION=0.0.0")
+	writeTestFile(t, filepath.Join(repoRoot, "demos", "spoke-zone-demo", "CMakeLists.txt"), "cmake_minimum_required(VERSION 3.16)")
+	writeTestFile(t, filepath.Join(repoRoot, "demos", "spoke-zone-demo", "main.cpp"), "int main() {}")
+	writeTestFile(t, filepath.Join(repoRoot, "demos", "spoke-zone-demo", ".qtcreator", "CMakeLists.txt.user"), "qtcreator state")
+	writeTestFile(t, filepath.Join(repoRoot, "demos", "spoke-zone-demo", "build", "artifact"), "generated")
+	runGit(t, repoRoot, "add", filepath.Join("demos", "README.md"))
+	runGit(t, repoRoot, "add", filepath.Join("demos", "can-simulator", "can-simulator.pro"))
+	runGit(t, repoRoot, "add", filepath.Join("demos", "can-simulator", "main.cpp"))
+	runGit(t, repoRoot, "add", filepath.Join("demos", "spoke-zone-demo", "CMakeLists.txt"))
+	runGit(t, repoRoot, "add", filepath.Join("demos", "spoke-zone-demo", "main.cpp"))
 }
 
 // writeTestFile creates a file and any missing parent directories so the test
@@ -87,5 +168,15 @@ func assertFileExists(t *testing.T, path string) {
 
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("expected file %s to exist: %v", path, err)
+	}
+}
+
+// assertFileMissing reports a focused failure if generated files leak into the
+// installed SDK demo tree when they should have been filtered out.
+func assertFileMissing(t *testing.T, path string) {
+	t.Helper()
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected file %s to be absent, stat error: %v", path, err)
 	}
 }

--- a/tools/mrs-sdk-manager/build_local/build_scope.go
+++ b/tools/mrs-sdk-manager/build_local/build_scope.go
@@ -1,0 +1,42 @@
+package buildlocal
+
+import "fmt"
+
+// BuildScope is the user-facing selector for which portions of the local
+// source tree should be built by the build-local command.
+type BuildScope string
+
+const (
+	BuildScopeAll   BuildScope = "all"
+	BuildScopeLibs  BuildScope = "libs"
+	BuildScopeDemos BuildScope = "demos"
+)
+
+// ParseBuildScope validates the optional positional target argument accepted by
+// `mrs-sdk-manager build-local`. An empty argument intentionally preserves the
+// documented default of `all`.
+func ParseBuildScope(raw string) (BuildScope, error) {
+	if raw == "" {
+		return BuildScopeAll, nil
+	}
+
+	scope := BuildScope(raw)
+	switch scope {
+	case BuildScopeAll, BuildScopeLibs, BuildScopeDemos:
+		return scope, nil
+	default:
+		return "", fmt.Errorf("invalid build target %q (expected one of: all, libs, demos)", raw)
+	}
+}
+
+// IncludesLibs reports whether the selected scope should build the SDK
+// libraries.
+func (scope BuildScope) IncludesLibs() bool {
+	return scope == BuildScopeAll || scope == BuildScopeLibs
+}
+
+// IncludesDemos reports whether the selected scope should build the demo
+// applications.
+func (scope BuildScope) IncludesDemos() bool {
+	return scope == BuildScopeAll || scope == BuildScopeDemos
+}

--- a/tools/mrs-sdk-manager/build_local/build_scope_test.go
+++ b/tools/mrs-sdk-manager/build_local/build_scope_test.go
@@ -1,0 +1,45 @@
+package buildlocal
+
+import "testing"
+
+// TestParseBuildScopeDefaultsToAll verifies that omitting the optional target
+// argument preserves the current broad behavior instead of forcing callers to
+// spell out the default explicitly.
+func TestParseBuildScopeDefaultsToAll(t *testing.T) {
+	scope, err := ParseBuildScope("")
+	if err != nil {
+		t.Fatalf("expected empty scope to default successfully, got error: %v", err)
+	}
+	if scope != BuildScopeAll {
+		t.Fatalf("expected empty scope to default to %q, got %q", BuildScopeAll, scope)
+	}
+}
+
+// TestParseBuildScopeAcceptsSupportedTargets verifies that the user-facing CLI
+// contract accepts each documented target selector.
+func TestParseBuildScopeAcceptsSupportedTargets(t *testing.T) {
+	testCases := []BuildScope{
+		BuildScopeAll,
+		BuildScopeLibs,
+		BuildScopeDemos,
+	}
+
+	for _, testCase := range testCases {
+		scope, err := ParseBuildScope(string(testCase))
+		if err != nil {
+			t.Fatalf("expected scope %q to parse successfully, got error: %v", testCase, err)
+		}
+		if scope != testCase {
+			t.Fatalf("expected scope %q to round-trip, got %q", testCase, scope)
+		}
+	}
+}
+
+// TestParseBuildScopeRejectsUnsupportedTargets verifies that typos and
+// undocumented selectors fail fast with a validation error instead of silently
+// changing the build behavior.
+func TestParseBuildScopeRejectsUnsupportedTargets(t *testing.T) {
+	if _, err := ParseBuildScope("widgets"); err == nil {
+		t.Fatal("expected unsupported scope to return an error")
+	}
+}

--- a/tools/mrs-sdk-manager/cmd/build_local.go
+++ b/tools/mrs-sdk-manager/cmd/build_local.go
@@ -2,32 +2,32 @@ package cmd
 
 import (
 	buildLocal "mrs-sdk-manager/build_local"
-	"os"
 
 	"github.com/spf13/cobra"
 )
 
 var buildLocalCmd = &cobra.Command{
-	Use:   "build-local",
-	Short: "Build the SDK library from source",
-	Long:  "Build the SDK library from source for all supported configurations (MConn/FUSION/desktop across Yocto/Buildroot/desktop OSes)",
-	Args:  cobra.NoArgs,
+	Use:   "build-local [TARGET]",
+	Short: "Build SDK libraries and/or demo projects from source",
+	Long:  "Build SDK libraries and/or demo projects from source. TARGET may be one of: all, libs, demos. Defaults to all.",
+	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := buildLocal.Build(); err != nil {
+		targetArg := ""
+		if len(args) == 1 {
+			targetArg = args[0]
+		}
+
+		scope, err := buildLocal.ParseBuildScope(targetArg)
+		if err != nil {
 			return err
 		}
+
 		installFlag, err := cmd.Flags().GetBool("install")
 		if err != nil {
 			return err
 		}
-		if installFlag {
-			sdkRoot, err := os.Getwd()
-			if err != nil {
-				return err
-			}
-			return buildLocal.InstallBuilds(sdkRoot)
-		}
-		return nil
+
+		return buildLocal.Run(scope, installFlag)
 	},
 }
 

--- a/tools/mrs-sdk-manager/utils/resolve_sdk_version.go
+++ b/tools/mrs-sdk-manager/utils/resolve_sdk_version.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// ResolveSDKVersion returns the latest annotated or lightweight Git tag for
+// the repository. If Git metadata is unavailable or the repository has not been
+// tagged yet, the function deliberately falls back to the long-standing local
+// development version string so installs remain deterministic.
+func ResolveSDKVersion(sdkRepoRoot string) string {
+	cmd := exec.Command("git", "describe", "--tags", "--abbrev=0")
+	cmd.Dir = sdkRepoRoot
+
+	output, err := cmd.Output()
+	if err != nil {
+		return "0.0.0"
+	}
+
+	version := strings.TrimSpace(string(output))
+	if version == "" {
+		return "0.0.0"
+	}
+
+	return version
+}

--- a/tools/mrs-sdk-manager/utils/resolve_sdk_version_test.go
+++ b/tools/mrs-sdk-manager/utils/resolve_sdk_version_test.go
@@ -1,0 +1,71 @@
+package utils
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolveSDKVersionUsesLatestGitTag verifies that local development
+// installs track the latest repository tag instead of always collapsing into a
+// synthetic 0.0.0 version. This keeps repo-local installs aligned with the
+// version metadata embedded into the built library itself.
+func TestResolveSDKVersionUsesLatestGitTag(t *testing.T) {
+	repoRoot := t.TempDir()
+
+	runGit(t, repoRoot, "init")
+	runGit(t, repoRoot, "config", "user.name", "Test User")
+	runGit(t, repoRoot, "config", "user.email", "test@example.com")
+	writeTestFile(t, filepath.Join(repoRoot, "README.md"), "initial")
+	runGit(t, repoRoot, "add", "README.md")
+	runGit(t, repoRoot, "commit", "-m", "initial commit")
+	runGit(t, repoRoot, "tag", "1.2.3")
+
+	version := ResolveSDKVersion(repoRoot)
+	if version != "1.2.3" {
+		t.Fatalf("expected latest git tag to be used as SDK version, got %q", version)
+	}
+}
+
+// TestResolveSDKVersionFallsBackWithoutGitTag verifies that local installs keep
+// the historical development fallback when the repository has no tag metadata.
+// That preserves a deterministic installation location for brand-new clones and
+// detached test fixtures.
+func TestResolveSDKVersionFallsBackWithoutGitTag(t *testing.T) {
+	repoRoot := t.TempDir()
+
+	version := ResolveSDKVersion(repoRoot)
+	if version != "0.0.0" {
+		t.Fatalf("expected untagged repositories to fall back to 0.0.0, got %q", version)
+	}
+}
+
+// runGit executes a Git command in the test repository and fails the test with
+// the full command output if Git refuses the operation. Keeping the helper here
+// avoids repetitive boilerplate in individual version-resolution tests while
+// still surfacing the exact failing subprocess invocation.
+func runGit(t *testing.T, repoRoot string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+}
+
+// writeTestFile creates a file and any missing parent directories so the test
+// fixtures stay focused on behavior instead of repetitive setup boilerplate.
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("failed to create directory for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary

- Added support for `mrs-sdk-manager build-local` to install demo apps
  - Accomplished via a target selector: `all|libs|demos`
  - Running `mrs-sdk-manager build-local all|demos --install` will copy the tracked files in the `demos` dir into the SDK installation tree
- `build-local` also checks Git tags for SDK version instead of hardcoding `0.0.0`
- `scripts/install_from_source.sh` updated to have a `demos` target

## Testing

- [x] `moon run install && tree $MRS_SDK_QT_ROOT` should show the demo apps at `$MRS_SDK_QT_ROOT/<version>/demos`

Related: #61 